### PR TITLE
Change the feed URL for Gecko

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ let feeds = [
   },
   */
   {
-    feedURL: 'https://groups.google.com/forum/feed/mozilla.dev.platform/topics/rss.xml?num=50',
+    feedURL: 'https://groups.google.com/a/mozilla.org/forum/feed/dev-platform/topics/rss.xml?num=50',
     searches: ['^intent to '],
     formatter: function(item) {
       return 'Gecko: ' + item.title + ' ' + item.link;


### PR DESCRIPTION
Early April, Mozilla moved its mailing list to a new group.
See the announcement there: https://groups.google.com/g/mozilla.dev.platform/c/cD0nt-dQ9Mw

That explains why the bot has not been tweeting any intent for Gecko since then 😉
This PR updates the feed URL to the new one to fix that.